### PR TITLE
Fix/login cors

### DIFF
--- a/src/main/java/com/ktb/paperplebe/auth/config/CorsConfig.java
+++ b/src/main/java/com/ktb/paperplebe/auth/config/CorsConfig.java
@@ -15,15 +15,15 @@ public class CorsConfig {
     @Value("${cors.allowed-origins.list}")
     private List<String> allowedOrigins;
 
-    @Bean(name = "localDevCorsConfigurationSource")
-    @Profile({"local", "dev"})
+    @Bean(name = "corsConfigurationSource")
+    @Profile({"local", "develop"})
     public CorsConfigurationSource localDevCorsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
         configuration.setAllowCredentials(true);
         configuration.setAllowedOrigins(allowedOrigins);
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-        configuration.setAllowedHeaders(List.of("Content-Type", "Authorization", "Accept", "Origin"));
+        configuration.setAllowedHeaders(List.of("Content-Type", "Authorization", "Accept", "Origin", "X-Requested-With"));
         configuration.setExposedHeaders(List.of("Authorization", "Location", "X-Custom-Header"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
@@ -32,7 +32,7 @@ public class CorsConfig {
         return source;
     }
 
-    @Bean(name = "prodCorsConfigurationSource")
+    @Bean(name = "corsConfigurationSource")
     @Profile({"prod"})
     public CorsConfigurationSource prodCorsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();

--- a/src/main/java/com/ktb/paperplebe/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ktb/paperplebe/oauth/handler/OAuth2SuccessHandler.java
@@ -20,10 +20,8 @@ import static org.springframework.http.HttpHeaders.SET_COOKIE;
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-
-    // TO DO - 프론트엔드 도메인 추가
-//    @Value("${app.properties.frontendDomain}")
-//    private String frontendDomain;
+    @Value("${app.properties.frontendDomain}")
+    private String frontendDomain;
 
     private final JwtUtil jwtUtil;
     private final CookieService cookieService;
@@ -46,7 +44,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             response.addHeader(SET_COOKIE, accessTokenCookie.toString());
             response.addHeader(SET_COOKIE, refreshTokenCookie.toString());
 
-//            response.sendRedirect(frontendDomain);
+            response.sendRedirect(frontendDomain);
         } catch (Exception e) {
             log.error("OAuth2 Login 성공 후 예외 발생 : {}", e.getMessage());
         }


### PR DESCRIPTION
# 구현 내용
- cors config bean 이름을 `corsConfigurationSource`로 변경
- 개발 환경에서의 Profile 이름을 `develop`으로 변경
- 소셜 로그인 후 프론트엔드 도메인으로 redirect

## Cors Config Bean의 이름을 `corsConfigurationSource`로 변경한 이유
Spring MVC의 자동 구성 중 `mvcHandlerMappingIntrospector`라는 이름의 CorsConfigurationSource 타입 빈이 생성됩니다. 따라서 Spring은 개발자가 생성한 빈(기존 `localDevCorsConfigurationSource`)과 Spring MVC에 의해 생성된 빈 중 어느 것을 선택해야 할지 모르기 때문에 오류를 발생시킵니다.

따라서 개발자가 생성한 빈의 이름을 `corsConfigurationSource`로 변경해 오류를 해결했습니다. Spring이 `CorsConfigurationSource` 타입의 빈을 찾을 때, 이름이 `corsConfigurationSource`인 빈을 우선적으로 선택하기 때문입니다.

Primary 어노테이션을 사용하여 명시적으로 빈을 주입할 수도 있지만, profile에 따라 환경 별로 다른 빈을 우선적으로 주입하게 되면 복잡성이 증가하는 것으로 판단해 빈의 이름을 변경하는 방법으로 문제를 해결했습니다.

# 관련 pr
https://github.com/lunch-12/PAPERPLE-FE/pull/2