### PR TITLE
feat: 유저 페이지 관련 API 추가 및 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    implementation 'software.amazon.awssdk:s3:2.20.40'
+
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
     compileOnly 'org.projectlombok:lombok'

--- a/src/docs/asciidoc/api-documnet.adoc
+++ b/src/docs/asciidoc/api-documnet.adoc
@@ -36,7 +36,7 @@ include::{snippets}/페이퍼 목록 조회/http-request.adoc[]
 include::{snippets}/페이퍼 목록 조회/http-response.adoc[]
 include::{snippets}/페이퍼 목록 조회/response-fields.adoc[]
 
-=== 수정
+=== _수정_
 
 ==== 요청
 

--- a/src/docs/asciidoc/api-documnet.adoc
+++ b/src/docs/asciidoc/api-documnet.adoc
@@ -26,6 +26,16 @@ include::{snippets}/페이퍼 조회/http-request.adoc[]
 include::{snippets}/페이퍼 조회/http-response.adoc[]
 include::{snippets}/페이퍼 조회/response-fields.adoc[]
 
+=== 목록 조회
+
+==== 요청
+
+include::{snippets}/페이퍼 목록 조회/http-request.adoc[]
+
+==== 응답
+include::{snippets}/페이퍼 목록 조회/http-response.adoc[]
+include::{snippets}/페이퍼 목록 조회/response-fields.adoc[]
+
 === 수정
 
 ==== 요청

--- a/src/main/java/com/ktb/paperplebe/aws/config/AwsS3Config.java
+++ b/src/main/java/com/ktb/paperplebe/aws/config/AwsS3Config.java
@@ -1,0 +1,28 @@
+package com.ktb.paperplebe.aws.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${aws.credentials.accessKeyId}")
+    private String accessKeyId;
+
+    @Value("${aws.credentials.secretAccessKey}")
+    private String secretAccessKey;
+
+    @Bean
+    public S3Presigner presigner() {
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKeyId, secretAccessKey);
+        return S3Presigner.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .region(Region.AP_NORTHEAST_2)
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/paperplebe/aws/controller/AwsController.java
+++ b/src/main/java/com/ktb/paperplebe/aws/controller/AwsController.java
@@ -1,0 +1,22 @@
+package com.ktb.paperplebe.aws.controller;
+
+import com.ktb.paperplebe.aws.service.AwsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/aws")
+@RequiredArgsConstructor
+@RestController
+public class AwsController {
+    private final AwsService awsService;
+
+    @GetMapping("/pre-signed-url/{filename}")
+    public ResponseEntity<String> getPreSignedUrl(@PathVariable String filename) {
+        return ResponseEntity.status(HttpStatus.OK).body(awsService.getPresignUrl(filename));
+    }
+}

--- a/src/main/java/com/ktb/paperplebe/aws/service/AwsService.java
+++ b/src/main/java/com/ktb/paperplebe/aws/service/AwsService.java
@@ -1,0 +1,43 @@
+package com.ktb.paperplebe.aws.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class AwsService {
+    
+    private final S3Presigner presigner;
+
+    public String getPresignUrl(String filename) {
+        if (filename == null || filename.equals("")) {
+            return null;
+        }
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket("ktb-test")
+                .key(filename)
+                .build();
+
+
+        PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+
+        PresignedPutObjectRequest presignedPutObjectRequest = presigner.presignPutObject(putObjectPresignRequest);
+
+        String url = presignedPutObjectRequest.url().toString();
+
+        presigner.close(); // presigner를 닫고 획득한 모든 리소스를 해제
+        return url;
+    }
+
+}

--- a/src/main/java/com/ktb/paperplebe/paper/controller/PaperController.java
+++ b/src/main/java/com/ktb/paperplebe/paper/controller/PaperController.java
@@ -5,6 +5,7 @@ import com.ktb.paperplebe.paper.dto.PaperResponse;
 import com.ktb.paperplebe.paper.service.PaperService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -14,8 +15,10 @@ public class PaperController {
     private final PaperService paperService;
 
     @PostMapping
-    public ResponseEntity<?> createPaper(@RequestBody final PaperRequest paperRequest) {
-        final PaperResponse paperResponse = paperService.createPaper(paperRequest);
+    public ResponseEntity<?> createPaper(
+            @RequestBody final PaperRequest paperRequest
+            ,@AuthenticationPrincipal Long userId) {
+        final PaperResponse paperResponse = paperService.createPaper(paperRequest, userId);
         return ResponseEntity.ok(paperResponse);
     }
 

--- a/src/main/java/com/ktb/paperplebe/paper/controller/PaperController.java
+++ b/src/main/java/com/ktb/paperplebe/paper/controller/PaperController.java
@@ -8,6 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @RequestMapping("/paper")
 @RestController
@@ -16,8 +18,8 @@ public class PaperController {
 
     @PostMapping
     public ResponseEntity<?> createPaper(
-            @RequestBody final PaperRequest paperRequest
-            ,@AuthenticationPrincipal Long userId) {
+            @RequestBody final PaperRequest paperRequest,
+            @AuthenticationPrincipal Long userId) {
         final PaperResponse paperResponse = paperService.createPaper(paperRequest, userId);
         return ResponseEntity.ok(paperResponse);
     }
@@ -28,8 +30,14 @@ public class PaperController {
         return ResponseEntity.ok(paperResponse);
     }
 
+    @GetMapping("/my-papers")
+    public ResponseEntity<?> getMyPapers(@AuthenticationPrincipal Long userId) {
+        List<PaperResponse> paperResponses = paperService.getPapersByUser(userId);
+        return ResponseEntity.ok(paperResponses);
+    }
+
     @PatchMapping("/{paperId}")
-    public ResponseEntity<?> updateRoom(
+    public ResponseEntity<?> updatePaper(
             @PathVariable Long paperId,
             @RequestBody final PaperRequest paperRequest) {
         final PaperResponse paperResponse = paperService.updatePaper(paperId, paperRequest);

--- a/src/main/java/com/ktb/paperplebe/paper/controller/PaperController.java
+++ b/src/main/java/com/ktb/paperplebe/paper/controller/PaperController.java
@@ -2,6 +2,7 @@ package com.ktb.paperplebe.paper.controller;
 
 import com.ktb.paperplebe.paper.dto.PaperRequest;
 import com.ktb.paperplebe.paper.dto.PaperResponse;
+import com.ktb.paperplebe.paper.dto.UserPaperResponse;
 import com.ktb.paperplebe.paper.service.PaperService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -30,9 +31,15 @@ public class PaperController {
         return ResponseEntity.ok(paperResponse);
     }
 
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<?> getUserPapers(@PathVariable Long userId) {
+        List<UserPaperResponse> paperResponse = paperService.getPapersByUser(userId);
+        return ResponseEntity.ok(paperResponse);
+    }
+
     @GetMapping("/my-papers")
     public ResponseEntity<?> getMyPapers(@AuthenticationPrincipal Long userId) {
-        List<PaperResponse> paperResponses = paperService.getPapersByUser(userId);
+        List<UserPaperResponse> paperResponses = paperService.getPapersByUser(userId);
         return ResponseEntity.ok(paperResponses);
     }
 

--- a/src/main/java/com/ktb/paperplebe/paper/controller/PaperController.java
+++ b/src/main/java/com/ktb/paperplebe/paper/controller/PaperController.java
@@ -32,14 +32,14 @@ public class PaperController {
     }
 
     @GetMapping("/user/{userId}")
-    public ResponseEntity<?> getUserPapers(@PathVariable Long userId) {
-        List<UserPaperResponse> paperResponse = paperService.getPapersByUser(userId);
-        return ResponseEntity.ok(paperResponse);
+    public ResponseEntity<?> getUserPapers(@PathVariable Long userId, @AuthenticationPrincipal Long currentUserId) {
+        List<UserPaperResponse> paperResponses = paperService.getPapersByUser(userId, currentUserId);
+        return ResponseEntity.ok(paperResponses);
     }
 
     @GetMapping("/my-papers")
     public ResponseEntity<?> getMyPapers(@AuthenticationPrincipal Long userId) {
-        List<UserPaperResponse> paperResponses = paperService.getPapersByUser(userId);
+        List<UserPaperResponse> paperResponses = paperService.getMyPapers(userId);
         return ResponseEntity.ok(paperResponses);
     }
 

--- a/src/main/java/com/ktb/paperplebe/paper/controller/PaperLikeController.java
+++ b/src/main/java/com/ktb/paperplebe/paper/controller/PaperLikeController.java
@@ -3,7 +3,10 @@ package com.ktb.paperplebe.paper.controller;
 import com.ktb.paperplebe.common.dto.SuccessResponse;
 import com.ktb.paperplebe.paper.service.PaperLikeFacade;
 import com.ktb.paperplebe.paper.service.PaperLikeService;
+import com.ktb.paperplebe.user.constant.UserRole;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,32 +27,34 @@ public class PaperLikeController {
     private final PaperLikeFacade paperLikeFacade;
 
     @PostMapping("/{paperId}/likes")
+    @Secured(UserRole.ROLE_USER_VALUE)
     public SuccessResponse increaseLikeCount(
-            //@AuthenticationPrincipal Long memberId,
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long paperId) throws InterruptedException {
         paperLikeFacade.increaseLikeCount(
-                //memberId,
+                userId,
                 paperId);
         return new SuccessResponse();
     }
 
     @DeleteMapping("/{paperId}/likes")
+    @Secured(UserRole.ROLE_USER_VALUE)
     public SuccessResponse decreaseLikeCount(
-            //@AuthenticationPrincipal Long memberId,
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long paperId) throws InterruptedException {
         paperLikeFacade.decreaseLikeCount(
-               //memberId,
+                userId,
                 paperId);
         return new SuccessResponse();
     }
 
     @GetMapping("/likes")
-    //@Secured(value = "ROLE_MEMBER")
+    @Secured(UserRole.ROLE_USER_VALUE)
     public Map<Long, Boolean> getLikeStatus(
-            //@AuthenticationPrincipal Long memberId,
+            @AuthenticationPrincipal Long userId,
             @RequestParam("paperIds") List<Long> paperIds) {
         return paperLikeService.getLikeStatus(
-                //memberId,
+                userId,
                 paperIds);
     }
 }

--- a/src/main/java/com/ktb/paperplebe/paper/dto/PaperResponse.java
+++ b/src/main/java/com/ktb/paperplebe/paper/dto/PaperResponse.java
@@ -2,13 +2,16 @@ package com.ktb.paperplebe.paper.dto;
 
 import com.ktb.paperplebe.paper.entity.Paper;
 
+import java.time.LocalDateTime;
+
 public record PaperResponse(
         Long paperId,
         String content,
         String newspaperLink,
         int view,
         String newspaperSummary,
-        String image
+        String image,
+        LocalDateTime createdAt
 ) {
     public static PaperResponse of(final Paper paper) {
         return new PaperResponse(
@@ -17,7 +20,8 @@ public record PaperResponse(
                 paper.getNewspaperLink(),
                 paper.getView(),
                 paper.getNewspaperSummary(),
-                paper.getImage()
+                paper.getImage(),
+                paper.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/ktb/paperplebe/paper/dto/UserPaperResponse.java
+++ b/src/main/java/com/ktb/paperplebe/paper/dto/UserPaperResponse.java
@@ -1,0 +1,31 @@
+package com.ktb.paperplebe.paper.dto;
+
+import com.ktb.paperplebe.paper.entity.Paper;
+
+import java.time.LocalDateTime;
+
+public record UserPaperResponse(
+        Long paperId,
+        String content,
+        String newspaperLink,
+        int view,
+        String newspaperSummary,
+        String image,
+        LocalDateTime createdAt,
+        String nickname,
+        String profileImage
+) {
+    public static UserPaperResponse of(final Paper paper, final String nickname, final String profileImage) {
+        return new UserPaperResponse(
+                paper.getId(),
+                paper.getContent(),
+                paper.getNewspaperLink(),
+                paper.getView(),
+                paper.getNewspaperSummary(),
+                paper.getImage(),
+                paper.getCreatedAt(),
+                nickname,
+                profileImage
+        );
+    }
+}

--- a/src/main/java/com/ktb/paperplebe/paper/dto/UserPaperResponse.java
+++ b/src/main/java/com/ktb/paperplebe/paper/dto/UserPaperResponse.java
@@ -3,6 +3,7 @@ package com.ktb.paperplebe.paper.dto;
 import com.ktb.paperplebe.paper.entity.Paper;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public record UserPaperResponse(
         Long paperId,
@@ -13,9 +14,10 @@ public record UserPaperResponse(
         String image,
         LocalDateTime createdAt,
         String nickname,
-        String profileImage
+        String profileImage,
+        boolean isLikedByCurrentUser
 ) {
-    public static UserPaperResponse of(final Paper paper, final String nickname, final String profileImage) {
+    public static UserPaperResponse of(final Paper paper, final String nickname, final String profileImage, final Optional<Boolean> isLikedByCurrentUser) {
         return new UserPaperResponse(
                 paper.getId(),
                 paper.getContent(),
@@ -25,7 +27,8 @@ public record UserPaperResponse(
                 paper.getImage(),
                 paper.getCreatedAt(),
                 nickname,
-                profileImage
+                profileImage,
+                isLikedByCurrentUser.orElse(false)
         );
     }
 }

--- a/src/main/java/com/ktb/paperplebe/paper/entity/Paper.java
+++ b/src/main/java/com/ktb/paperplebe/paper/entity/Paper.java
@@ -42,6 +42,9 @@ public class Paper {
     @OneToMany(mappedBy = "paper", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PaperLike> likes = new ArrayList<>();
 
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
     private Paper(final String content, final String newspaperLink, final int view, final String newspaperSummary, final String image, final User user) {
         this.content = content;
         this.newspaperLink = newspaperLink;
@@ -91,5 +94,10 @@ public class Paper {
 
     public void updateImage(final String image) {
         this.image = image;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/ktb/paperplebe/paper/entity/Paper.java
+++ b/src/main/java/com/ktb/paperplebe/paper/entity/Paper.java
@@ -1,5 +1,6 @@
 package com.ktb.paperplebe.paper.entity;
 
+import com.ktb.paperplebe.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -34,19 +35,24 @@ public class Paper {
     @Column(length = 255)
     private String image;
 
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
     @OneToMany(mappedBy = "paper", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PaperLike> likes = new ArrayList<>();
 
-    private Paper(final String content, final String newspaperLink, final int view, final String newspaperSummary, final String image) {
+    private Paper(final String content, final String newspaperLink, final int view, final String newspaperSummary, final String image, final User user) {
         this.content = content;
         this.newspaperLink = newspaperLink;
         this.view = view;
         this.newspaperSummary = newspaperSummary;
         this.image = image;
+        this.user = user;
     }
 
-    public static Paper of(final String content, final String newspaperLink, final int view, final String newspaperSummary, final String image) {
-        return new Paper(content, newspaperLink, view, newspaperSummary, image);
+    public static Paper of(final String content, final String newspaperLink, final int view, final String newspaperSummary, final String image, final User user) {
+        return new Paper(content, newspaperLink, view, newspaperSummary, image, user);
     }
 
     // 좋아요 수 관련 메서드

--- a/src/main/java/com/ktb/paperplebe/paper/entity/PaperLike.java
+++ b/src/main/java/com/ktb/paperplebe/paper/entity/PaperLike.java
@@ -1,5 +1,6 @@
 package com.ktb.paperplebe.paper.entity;
 
+import com.ktb.paperplebe.user.entity.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,17 +22,16 @@ public class PaperLike {
     @JoinColumn(name = "paper_id")
     private Paper paper;
 
-//    @ManyToOne
-//    @JoinColumn(name = "member_id")
-//    private Member member;
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Builder
-    public PaperLike(Paper paper
-            //, Member member
+    public PaperLike(Paper paper, User user
     ) {
         this.paper = paper;
-        //this.member = member;
-        //assignPaper(paper);
+        this.user = user;
+        assignPaper(paper);
     }
 
     public PaperLike() {

--- a/src/main/java/com/ktb/paperplebe/paper/repository/PaperLikeRepository.java
+++ b/src/main/java/com/ktb/paperplebe/paper/repository/PaperLikeRepository.java
@@ -14,7 +14,7 @@ public interface PaperLikeRepository extends JpaRepository<PaperLike, Long> {
     Optional<PaperLike> findByPaper_Id(Long paperId);
 
     // 여러 Paper 엔티티의 id를 기준으로 PaperLike 엔티티 목록 조회
-    List<PaperLike> findByPaper_IdIn(List<Long> paperIds);
+    List<PaperLike> findByPaper_IdInAndUser_Id(List<Long> paperIds, Long userId);
 
     Optional<PaperLike> findByPaper_IdAndUser_Id(Long paperId, Long userId);
 }

--- a/src/main/java/com/ktb/paperplebe/paper/repository/PaperLikeRepository.java
+++ b/src/main/java/com/ktb/paperplebe/paper/repository/PaperLikeRepository.java
@@ -15,4 +15,6 @@ public interface PaperLikeRepository extends JpaRepository<PaperLike, Long> {
 
     // 여러 Paper 엔티티의 id를 기준으로 PaperLike 엔티티 목록 조회
     List<PaperLike> findByPaper_IdIn(List<Long> paperIds);
+
+    Optional<PaperLike> findByPaper_IdAndUser_Id(Long paperId, Long userId);
 }

--- a/src/main/java/com/ktb/paperplebe/paper/repository/PaperRepository.java
+++ b/src/main/java/com/ktb/paperplebe/paper/repository/PaperRepository.java
@@ -7,5 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface PaperRepository extends JpaRepository<Paper, Long> {
-    List<Paper> findByContentContaining(String keyword , Pageable pageable);
+
+    List<Paper> findByContentContaining(String keyword, Pageable pageable);
+
+    List<Paper> findByUserId(Long userId);
 }

--- a/src/main/java/com/ktb/paperplebe/paper/service/PaperLikeFacade.java
+++ b/src/main/java/com/ktb/paperplebe/paper/service/PaperLikeFacade.java
@@ -21,11 +21,11 @@ public class PaperLikeFacade {
         }
     }
 
-    public void increaseLikeCount(Long paperId) throws InterruptedException {
-        executeWithRetry(() -> paperLikeService.increaseLikeCount(paperId));
+    public void increaseLikeCount(Long userId, Long paperId) throws InterruptedException {
+        executeWithRetry(() -> paperLikeService.increaseLikeCount(userId, paperId));
     }
 
-    public void decreaseLikeCount(Long paperId) throws InterruptedException {
-        executeWithRetry(() -> paperLikeService.decreaseLikeCount(paperId));
+    public void decreaseLikeCount(Long userId, Long paperId) throws InterruptedException {
+        executeWithRetry(() -> paperLikeService.decreaseLikeCount(userId, paperId));
     }
 }

--- a/src/main/java/com/ktb/paperplebe/paper/service/PaperLikeService.java
+++ b/src/main/java/com/ktb/paperplebe/paper/service/PaperLikeService.java
@@ -5,6 +5,8 @@ import com.ktb.paperplebe.paper.entity.PaperLike;
 import com.ktb.paperplebe.paper.exception.PaperLikeException;
 import com.ktb.paperplebe.paper.repository.PaperLikeRepository;
 import com.ktb.paperplebe.paper.repository.PaperRepository;
+import com.ktb.paperplebe.user.entity.User;
+import com.ktb.paperplebe.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 import static com.ktb.paperplebe.paper.exception.PaperLikeErrorCode.PAPER_ALREADY_LIKED;
 import static com.ktb.paperplebe.paper.exception.PaperLikeErrorCode.PAPER_NOT_FOUND;
@@ -24,22 +25,27 @@ public class PaperLikeService {
 
     private final PaperLikeRepository paperLikeRepository;
     private final PaperRepository paperRepository;
+    private final UserService userService;
 
-    public void increaseLikeCount(Long paperId) {
+    public void increaseLikeCount(Long userId, Long paperId) {
         if (paperLikeRepository.existsByPaper_Id(paperId)) {
             throw new PaperLikeException(PAPER_ALREADY_LIKED);
         }
 
-        Paper findPaper = findPaperOrThrow(paperId);
 
-        PaperLike like = new PaperLike(findPaper);
+        Paper findPaper = findPaperOrThrow(paperId);
+        User findUser = userService.findById(userId);
+
+        PaperLike like = new PaperLike(findPaper, findUser);
         findPaper.addLike(like);
 
         paperLikeRepository.save(like);
     }
 
-    public void decreaseLikeCount(Long paperId) {
-        PaperLike like = paperLikeRepository.findByPaper_Id(paperId).orElseThrow(() -> new IllegalStateException("This paper was not previously liked."));
+    public void decreaseLikeCount(Long userId, Long paperId) {
+        PaperLike like = paperLikeRepository.findByPaper_IdAndUser_Id(paperId, userId)
+                .orElseThrow(() -> new IllegalStateException("This paper was not previously liked by this user."));
+
         Paper findPaper = findPaperOrThrow(paperId);
 
         findPaper.removeLike(like);
@@ -47,7 +53,7 @@ public class PaperLikeService {
         paperLikeRepository.delete(like);
     }
 
-    public Map<Long, Boolean> getLikeStatus(List<Long> paperIds) {
+    public Map<Long, Boolean> getLikeStatus(Long userId, List<Long> paperIds) {
         List<PaperLike> paperLikes = paperLikeRepository.findByPaper_IdIn(paperIds);
 
         Map<Long, Boolean> result = new HashMap<>();

--- a/src/main/java/com/ktb/paperplebe/paper/service/PaperLikeService.java
+++ b/src/main/java/com/ktb/paperplebe/paper/service/PaperLikeService.java
@@ -54,8 +54,7 @@ public class PaperLikeService {
     }
 
     public Map<Long, Boolean> getLikeStatus(Long userId, List<Long> paperIds) {
-        List<PaperLike> paperLikes = paperLikeRepository.findByPaper_IdIn(paperIds);
-
+        List<PaperLike> paperLikes = paperLikeRepository.findByPaper_IdInAndUser_Id(paperIds, userId);
         Map<Long, Boolean> result = new HashMap<>();
 
         paperLikes.forEach(paperLike -> result.put(paperLike.getPaper().getId(), true));

--- a/src/main/java/com/ktb/paperplebe/paper/service/PaperService.java
+++ b/src/main/java/com/ktb/paperplebe/paper/service/PaperService.java
@@ -5,6 +5,8 @@ import com.ktb.paperplebe.paper.dto.PaperResponse;
 import com.ktb.paperplebe.paper.entity.Paper;
 import com.ktb.paperplebe.paper.exception.PaperException;
 import com.ktb.paperplebe.paper.repository.PaperRepository;
+import com.ktb.paperplebe.user.entity.User;
+import com.ktb.paperplebe.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,15 +18,19 @@ import static com.ktb.paperplebe.paper.exception.PaperErrorCode.PAPER_NOT_FOUND;
 @Transactional(readOnly = true)
 public class PaperService {
     private final PaperRepository paperRepository;
+    private final UserService userService;
 
     @Transactional
-    public PaperResponse createPaper(PaperRequest paperRequest) {
+    public PaperResponse createPaper(PaperRequest paperRequest, Long userId) {
+        User user = userService.findById(userId);
+
         Paper paper = Paper.of(
                 paperRequest.content(),
                 paperRequest.newspaperLink(),
                 paperRequest.view(),
                 paperRequest.newspaperSummary(),
-                paperRequest.image()
+                paperRequest.image(),
+                user
         );
 
         Paper savedPaper = paperRepository.save(paper);

--- a/src/main/java/com/ktb/paperplebe/paper/service/PaperService.java
+++ b/src/main/java/com/ktb/paperplebe/paper/service/PaperService.java
@@ -11,6 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static com.ktb.paperplebe.paper.exception.PaperErrorCode.PAPER_NOT_FOUND;
 
 @RequiredArgsConstructor
@@ -54,6 +57,13 @@ public class PaperService {
     public PaperResponse getPaper(Long paperId) {
         Paper paper = findPaperByIdOrThrow(paperId);
         return PaperResponse.of(paper);
+    }
+
+    public List<PaperResponse> getPapersByUser(Long userId) {
+        List<Paper> papers = paperRepository.findByUserId(userId);
+        return papers.stream()
+                .map(PaperResponse::of)
+                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/main/java/com/ktb/paperplebe/paper/service/PaperService.java
+++ b/src/main/java/com/ktb/paperplebe/paper/service/PaperService.java
@@ -2,6 +2,7 @@ package com.ktb.paperplebe.paper.service;
 
 import com.ktb.paperplebe.paper.dto.PaperRequest;
 import com.ktb.paperplebe.paper.dto.PaperResponse;
+import com.ktb.paperplebe.paper.dto.UserPaperResponse;
 import com.ktb.paperplebe.paper.entity.Paper;
 import com.ktb.paperplebe.paper.exception.PaperException;
 import com.ktb.paperplebe.paper.repository.PaperRepository;
@@ -59,10 +60,11 @@ public class PaperService {
         return PaperResponse.of(paper);
     }
 
-    public List<PaperResponse> getPapersByUser(Long userId) {
+    public List<UserPaperResponse> getPapersByUser(Long userId) {
+        User user = userService.findById(userId);
         List<Paper> papers = paperRepository.findByUserId(userId);
         return papers.stream()
-                .map(PaperResponse::of)
+                .map(paper -> UserPaperResponse.of(paper, user.getNickname(), user.getProfileImage()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/ktb/paperplebe/user/controller/UserController.java
+++ b/src/main/java/com/ktb/paperplebe/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.ktb.paperplebe.user.controller;
 import com.ktb.paperplebe.user.constant.UserRole;
 import com.ktb.paperplebe.user.dto.UserInfoResponse;
 import com.ktb.paperplebe.user.dto.UserNicknameRequest;
+import com.ktb.paperplebe.user.dto.UserProfileImageRequest;
 import com.ktb.paperplebe.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.annotation.Secured;
@@ -31,5 +32,14 @@ public class UserController {
             @AuthenticationPrincipal Long userId
     ) {
         return userService.updateNickname(userId, nicknameRequest.getNickname());
+    }
+
+    @Secured(UserRole.ROLE_USER_VALUE)
+    @PatchMapping("/profile-image")
+    public UserInfoResponse updateProfileImage(
+            @RequestBody UserProfileImageRequest profileImageRequest,
+            @AuthenticationPrincipal Long userId
+    ) {
+        return userService.updateProfileImage(userId, profileImageRequest.getProfileImage());
     }
 }

--- a/src/main/java/com/ktb/paperplebe/user/dto/UserProfileImageRequest.java
+++ b/src/main/java/com/ktb/paperplebe/user/dto/UserProfileImageRequest.java
@@ -1,0 +1,12 @@
+package com.ktb.paperplebe.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class UserProfileImageRequest {
+    private String profileImage;
+}

--- a/src/main/java/com/ktb/paperplebe/user/entity/User.java
+++ b/src/main/java/com/ktb/paperplebe/user/entity/User.java
@@ -2,6 +2,7 @@ package com.ktb.paperplebe.user.entity;
 
 import com.ktb.paperplebe.oauth.constant.SocialType;
 import com.ktb.paperplebe.paper.entity.Paper;
+import com.ktb.paperplebe.paper.entity.PaperLike;
 import com.ktb.paperplebe.user.constant.UserRole;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -34,6 +35,9 @@ public class User {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Paper> papers;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PaperLike> paperLikes;
 
     @Builder
     public User(String nickname, String socialId, UserRole role, SocialType socialType, String profileImage) {

--- a/src/main/java/com/ktb/paperplebe/user/entity/User.java
+++ b/src/main/java/com/ktb/paperplebe/user/entity/User.java
@@ -1,12 +1,15 @@
 package com.ktb.paperplebe.user.entity;
 
 import com.ktb.paperplebe.oauth.constant.SocialType;
+import com.ktb.paperplebe.paper.entity.Paper;
 import com.ktb.paperplebe.user.constant.UserRole;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -29,6 +32,8 @@ public class User {
     @Enumerated(EnumType.STRING)
     private SocialType socialType;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Paper> papers;
 
     @Builder
     public User(String nickname, String socialId, UserRole role, SocialType socialType, String profileImage) {
@@ -41,5 +46,9 @@ public class User {
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
     }
 }

--- a/src/main/java/com/ktb/paperplebe/user/exception/UserErrorCode.java
+++ b/src/main/java/com/ktb/paperplebe/user/exception/UserErrorCode.java
@@ -1,0 +1,19 @@
+package com.ktb.paperplebe.user.exception;
+
+import com.ktb.paperplebe.common.exception.DomainErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum UserErrorCode implements DomainErrorCode {
+    NICKNAME_DUPLICATED("이미 존재하는 닉네임입니다.", HttpStatus.CONFLICT),
+    USER_NOT_FOUND("요청하신 유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String message;
+    private final HttpStatus status;
+
+    UserErrorCode(final String message, final HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/ktb/paperplebe/user/exception/UserException.java
+++ b/src/main/java/com/ktb/paperplebe/user/exception/UserException.java
@@ -1,0 +1,9 @@
+package com.ktb.paperplebe.user.exception;
+
+import com.ktb.paperplebe.common.exception.DomainException;
+
+public class UserException extends DomainException {
+    public UserException(final UserErrorCode errorCode)  {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/ktb/paperplebe/user/service/UserService.java
+++ b/src/main/java/com/ktb/paperplebe/user/service/UserService.java
@@ -2,10 +2,14 @@ package com.ktb.paperplebe.user.service;
 
 import com.ktb.paperplebe.user.dto.UserInfoResponse;
 import com.ktb.paperplebe.user.entity.User;
+import com.ktb.paperplebe.user.exception.UserException;
 import com.ktb.paperplebe.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import static com.ktb.paperplebe.user.exception.UserErrorCode.USER_NOT_FOUND;
+import static com.ktb.paperplebe.user.exception.UserErrorCode.NICKNAME_DUPLICATED;
 
 @Service
 @RequiredArgsConstructor
@@ -14,11 +18,18 @@ public class UserService {
 
     public User findById(Long id) {
         return userRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Invalid user ID: " + id));
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
     }
 
     public UserInfoResponse getUserInfo(Long id) {
         User user = findById(id);
+        return UserInfoResponse.of(user);
+    }
+
+    @Transactional
+    public UserInfoResponse updateProfileImage(Long userId, String profileImage) {
+        User user = findById(userId);
+        user.updateProfileImage(profileImage);
         return UserInfoResponse.of(user);
     }
 
@@ -34,7 +45,8 @@ public class UserService {
 
     private void validateDuplicatedNickname(String nickname) {
         if (existsByNickname(nickname)) {
-            throw new RuntimeException(nickname + "은 이미 사용 중인 닉네임입니다.");
+            System.out.println("@@@ here");
+            throw new UserException(NICKNAME_DUPLICATED);
         }
     }
 

--- a/src/test/java/com/ktb/paperplebe/paper/controller/PaperControllerTest.java
+++ b/src/test/java/com/ktb/paperplebe/paper/controller/PaperControllerTest.java
@@ -5,6 +5,7 @@ import com.ktb.paperplebe.auth.config.jwt.JwtAuthorizationFilter;
 import com.ktb.paperplebe.auth.config.jwt.JwtUtil;
 import com.ktb.paperplebe.paper.dto.PaperRequest;
 import com.ktb.paperplebe.paper.dto.PaperResponse;
+import com.ktb.paperplebe.paper.dto.UserPaperResponse;
 import com.ktb.paperplebe.paper.fixture.PaperFixture;
 import com.ktb.paperplebe.paper.service.PaperService;
 import org.junit.jupiter.api.DisplayName;
@@ -26,8 +27,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
@@ -134,7 +133,7 @@ public class PaperControllerTest {
     @WithMockUser
     public void getMyPapers() throws Exception {
         // given
-        final List<PaperResponse> expectedResponse = PaperFixture.createPaperResponseList();
+        final List<UserPaperResponse> expectedResponse = PaperFixture.createUserPaperResponseList();
         given(paperService.getPapersByUser(any())).willReturn(expectedResponse);
 
         // when
@@ -155,7 +154,9 @@ public class PaperControllerTest {
                         fieldWithPath("[].view").type(NUMBER).description("조회수"),
                         fieldWithPath("[].newspaperSummary").type(STRING).description("신문 요약"),
                         fieldWithPath("[].image").type(STRING).optional().description("이미지 URL"),
-                        fieldWithPath("[].createdAt").type(STRING).description("생성 시간")
+                        fieldWithPath("[].createdAt").type(STRING).description("생성 시간"),
+                        fieldWithPath("[].nickname").type(STRING).description("작성자 닉네임"),
+                        fieldWithPath("[].profileImage").type(STRING).description("작성자 프로필 이미지 URL")
                 )
         ));
     }

--- a/src/test/java/com/ktb/paperplebe/paper/controller/PaperControllerTest.java
+++ b/src/test/java/com/ktb/paperplebe/paper/controller/PaperControllerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -134,7 +135,7 @@ public class PaperControllerTest {
     public void getMyPapers() throws Exception {
         // given
         final List<UserPaperResponse> expectedResponse = PaperFixture.createUserPaperResponseList();
-        given(paperService.getPapersByUser(any())).willReturn(expectedResponse);
+        given(paperService.getMyPapers(any())).willReturn(expectedResponse);
 
         // when
         ResultActions resultActions = mockMvc.perform(get("/paper/my-papers")
@@ -156,7 +157,8 @@ public class PaperControllerTest {
                         fieldWithPath("[].image").type(STRING).optional().description("이미지 URL"),
                         fieldWithPath("[].createdAt").type(STRING).description("생성 시간"),
                         fieldWithPath("[].nickname").type(STRING).description("작성자 닉네임"),
-                        fieldWithPath("[].profileImage").type(STRING).description("작성자 프로필 이미지 URL")
+                        fieldWithPath("[].profileImage").type(STRING).description("작성자 프로필 이미지 URL"),
+                        fieldWithPath("[].isLikedByCurrentUser").type(BOOLEAN).description("현재 로그인한 유저의 좋아요 여부")
                 )
         ));
     }

--- a/src/test/java/com/ktb/paperplebe/paper/controller/PaperControllerTest.java
+++ b/src/test/java/com/ktb/paperplebe/paper/controller/PaperControllerTest.java
@@ -77,7 +77,8 @@ public class PaperControllerTest {
                         fieldWithPath("newspaperLink").description("신문 링크"),
                         fieldWithPath("view").description("조회수"),
                         fieldWithPath("newspaperSummary").description("신문 요약"),
-                        fieldWithPath("image").description("이미지 URL")
+                        fieldWithPath("image").description("이미지 URL"),
+                        fieldWithPath("createdAt").type(STRING).optional().description("생성 시간")
                 ),
                 responseFields(
                         fieldWithPath("paperId").type(NUMBER).description("페이퍼 ID"),
@@ -85,7 +86,8 @@ public class PaperControllerTest {
                         fieldWithPath("newspaperLink").type(STRING).description("신문 링크"),
                         fieldWithPath("view").type(NUMBER).description("조회수"),
                         fieldWithPath("newspaperSummary").type(STRING).description("신문 요약"),
-                        fieldWithPath("image").type(STRING).description("이미지 URL")
+                        fieldWithPath("image").type(STRING).description("이미지 URL"),
+                        fieldWithPath("createdAt").type(STRING).optional().description("생성 시간")
                 )
         ));
     }
@@ -116,7 +118,8 @@ public class PaperControllerTest {
                         fieldWithPath("newspaperLink").type(STRING).description("신문 링크"),
                         fieldWithPath("view").type(NUMBER).description("조회수"),
                         fieldWithPath("newspaperSummary").type(STRING).description("신문 요약"),
-                        fieldWithPath("image").type(STRING).description("이미지 URL")
+                        fieldWithPath("image").type(STRING).description("이미지 URL"),
+                        fieldWithPath("createdAt").description("생성 시간")
                 )
         ));
     }
@@ -149,7 +152,8 @@ public class PaperControllerTest {
                         fieldWithPath("newspaperLink").description("신문 링크"),
                         fieldWithPath("view").description("조회수"),
                         fieldWithPath("newspaperSummary").description("신문 요약"),
-                        fieldWithPath("image").description("이미지 URL")
+                        fieldWithPath("image").description("이미지 URL"),
+                        fieldWithPath("createdAt").type(STRING).optional().description("생성 시간")
                 ),
                 responseFields(
                         fieldWithPath("paperId").type(NUMBER).description("페이퍼 ID"),
@@ -157,7 +161,8 @@ public class PaperControllerTest {
                         fieldWithPath("newspaperLink").type(STRING).description("신문 링크"),
                         fieldWithPath("view").type(NUMBER).description("조회수"),
                         fieldWithPath("newspaperSummary").type(STRING).description("신문 요약"),
-                        fieldWithPath("image").type(STRING).description("이미지 URL")
+                        fieldWithPath("image").type(STRING).description("이미지 URL"),
+                        fieldWithPath("createdAt").type(STRING).optional().description("생성 시간")
                 )
         ));
     }

--- a/src/test/java/com/ktb/paperplebe/paper/controller/PaperControllerTest.java
+++ b/src/test/java/com/ktb/paperplebe/paper/controller/PaperControllerTest.java
@@ -19,10 +19,15 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
@@ -123,6 +128,38 @@ public class PaperControllerTest {
                 )
         ));
     }
+
+    @Test
+    @DisplayName("페이퍼 목록 조회")
+    @WithMockUser
+    public void getMyPapers() throws Exception {
+        // given
+        final List<PaperResponse> expectedResponse = PaperFixture.createPaperResponseList();
+        given(paperService.getPapersByUser(any())).willReturn(expectedResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/paper/my-papers")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf().asHeader())
+        );
+
+        // then
+        resultActions.andExpect(status().isOk());
+
+        // restdocs
+        resultActions.andDo(document("페이퍼 목록 조회",
+                responseFields(
+                        fieldWithPath("[].paperId").type(NUMBER).description("페이퍼 ID"),
+                        fieldWithPath("[].content").type(STRING).description("내용"),
+                        fieldWithPath("[].newspaperLink").type(STRING).description("신문 링크"),
+                        fieldWithPath("[].view").type(NUMBER).description("조회수"),
+                        fieldWithPath("[].newspaperSummary").type(STRING).description("신문 요약"),
+                        fieldWithPath("[].image").type(STRING).optional().description("이미지 URL"),
+                        fieldWithPath("[].createdAt").type(STRING).description("생성 시간")
+                )
+        ));
+    }
+
 
     @Test
     @DisplayName("페이퍼 수정")

--- a/src/test/java/com/ktb/paperplebe/paper/controller/PaperControllerTest.java
+++ b/src/test/java/com/ktb/paperplebe/paper/controller/PaperControllerTest.java
@@ -3,7 +3,6 @@ package com.ktb.paperplebe.paper.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ktb.paperplebe.auth.config.jwt.JwtAuthorizationFilter;
 import com.ktb.paperplebe.auth.config.jwt.JwtUtil;
-import com.ktb.paperplebe.paper.controller.PaperController;
 import com.ktb.paperplebe.paper.dto.PaperRequest;
 import com.ktb.paperplebe.paper.dto.PaperResponse;
 import com.ktb.paperplebe.paper.fixture.PaperFixture;
@@ -33,6 +32,8 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 
+
+
 @WebMvcTest(value = PaperController.class, excludeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthorizationFilter.class),
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class),
@@ -57,7 +58,7 @@ public class PaperControllerTest {
         final PaperRequest paperRequest = PaperFixture.createPaperRequest1();
         final PaperResponse expectedResponse = PaperFixture.createPaperResponse1();
 
-        given(paperService.createPaper(any(PaperRequest.class))).willReturn(expectedResponse);
+        given(paperService.createPaper(any(PaperRequest.class), any())).willReturn(expectedResponse);
 
         // when
         ResultActions resultActions = mockMvc.perform(post("/paper")

--- a/src/test/java/com/ktb/paperplebe/paper/controller/PaperLikeControllerTest.java
+++ b/src/test/java/com/ktb/paperplebe/paper/controller/PaperLikeControllerTest.java
@@ -58,7 +58,7 @@ public class PaperLikeControllerTest {
     @WithMockUser
     public void increaseLikeCount() throws Exception {
         // given
-        willDoNothing().given(paperLikeFacade).increaseLikeCount(anyLong());
+        willDoNothing().given(paperLikeFacade).increaseLikeCount(anyLong(), anyLong());
 
         // when
         ResultActions resultActions = mockMvc.perform(post("/paper/{paperId}/likes", PaperLikeFixture.PAPER_ID_1)
@@ -83,7 +83,7 @@ public class PaperLikeControllerTest {
     @WithMockUser
     public void decreaseLikeCount() throws Exception {
         // given
-        willDoNothing().given(paperLikeFacade).decreaseLikeCount(anyLong());
+        willDoNothing().given(paperLikeFacade).decreaseLikeCount(anyLong(), anyLong());
 
         // when
         ResultActions resultActions = mockMvc.perform(delete("/paper/{paperId}/likes", PaperLikeFixture.PAPER_ID_1)
@@ -109,7 +109,7 @@ public class PaperLikeControllerTest {
     public void getLikeStatus() throws Exception {
         // given
         Map<Long, Boolean> likeStatus = PaperLikeFixture.createLikeStatus();
-        given(paperLikeService.getLikeStatus(any())).willReturn(likeStatus);
+        given(paperLikeService.getLikeStatus(any(), any())).willReturn(likeStatus);
 
         // when
         ResultActions resultActions = mockMvc.perform(get("/paper/likes")

--- a/src/test/java/com/ktb/paperplebe/paper/fixture/PaperFixture.java
+++ b/src/test/java/com/ktb/paperplebe/paper/fixture/PaperFixture.java
@@ -35,13 +35,15 @@ public class PaperFixture {
     public static final User DUMMY_USER = createDummyUser();
 
     private static User createDummyUser() {
-        return User.builder()
+        User user = User.builder()
                 .nickname("TestUser")
                 .socialId("testUser123")
                 .role(UserRole.ROLE_USER)
                 .socialType(SocialType.KAKAO)
                 .profileImage("http://example.com/profile.jpg")
                 .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        return user;
     }
 
     public static Paper createPaper1() {

--- a/src/test/java/com/ktb/paperplebe/paper/fixture/PaperFixture.java
+++ b/src/test/java/com/ktb/paperplebe/paper/fixture/PaperFixture.java
@@ -12,6 +12,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class PaperFixture {
 
@@ -89,13 +90,13 @@ public class PaperFixture {
     public static UserPaperResponse createUserPaperResponse1() {
         Paper paper = createPaper1();
         ReflectionTestUtils.setField(paper, "createdAt", LocalDateTime.now());
-        return UserPaperResponse.of(paper, DUMMY_USER.getNickname(), DUMMY_USER.getProfileImage());
+        return UserPaperResponse.of(paper, DUMMY_USER.getNickname(), DUMMY_USER.getProfileImage(), Optional.empty());
     }
 
     public static UserPaperResponse createUserPaperResponse2() {
         Paper paper = createPaper2();
         ReflectionTestUtils.setField(paper, "createdAt", LocalDateTime.now());
-        return UserPaperResponse.of(paper, DUMMY_USER.getNickname(), DUMMY_USER.getProfileImage());
+        return UserPaperResponse.of(paper, DUMMY_USER.getNickname(), DUMMY_USER.getProfileImage(), Optional.empty());
     }
 
     public static List<UserPaperResponse> createUserPaperResponseList() {

--- a/src/test/java/com/ktb/paperplebe/paper/fixture/PaperFixture.java
+++ b/src/test/java/com/ktb/paperplebe/paper/fixture/PaperFixture.java
@@ -8,6 +8,7 @@ import com.ktb.paperplebe.user.constant.UserRole;
 import com.ktb.paperplebe.user.entity.User;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -65,11 +66,13 @@ public class PaperFixture {
 
     public static PaperResponse createPaperResponse1() {
         Paper paper = createPaper1();
+        ReflectionTestUtils.setField(paper, "createdAt", LocalDateTime.now());
         return PaperResponse.of(paper);
     }
 
     public static PaperResponse createPaperResponse2() {
         Paper paper = createPaper2();
+        ReflectionTestUtils.setField(paper, "createdAt", LocalDateTime.now());
         return PaperResponse.of(paper);
     }
 

--- a/src/test/java/com/ktb/paperplebe/paper/fixture/PaperFixture.java
+++ b/src/test/java/com/ktb/paperplebe/paper/fixture/PaperFixture.java
@@ -3,6 +3,7 @@ package com.ktb.paperplebe.paper.fixture;
 import com.ktb.paperplebe.oauth.constant.SocialType;
 import com.ktb.paperplebe.paper.dto.PaperRequest;
 import com.ktb.paperplebe.paper.dto.PaperResponse;
+import com.ktb.paperplebe.paper.dto.UserPaperResponse;
 import com.ktb.paperplebe.paper.entity.Paper;
 import com.ktb.paperplebe.user.constant.UserRole;
 import com.ktb.paperplebe.user.entity.User;
@@ -82,6 +83,25 @@ public class PaperFixture {
         List<PaperResponse> paperResponses = new ArrayList<>();
         paperResponses.add(createPaperResponse1());
         paperResponses.add(createPaperResponse2());
+        return paperResponses;
+    }
+
+    public static UserPaperResponse createUserPaperResponse1() {
+        Paper paper = createPaper1();
+        ReflectionTestUtils.setField(paper, "createdAt", LocalDateTime.now());
+        return UserPaperResponse.of(paper, DUMMY_USER.getNickname(), DUMMY_USER.getProfileImage());
+    }
+
+    public static UserPaperResponse createUserPaperResponse2() {
+        Paper paper = createPaper2();
+        ReflectionTestUtils.setField(paper, "createdAt", LocalDateTime.now());
+        return UserPaperResponse.of(paper, DUMMY_USER.getNickname(), DUMMY_USER.getProfileImage());
+    }
+
+    public static List<UserPaperResponse> createUserPaperResponseList() {
+        List<UserPaperResponse> paperResponses = new ArrayList<>();
+        paperResponses.add(createUserPaperResponse1());
+        paperResponses.add(createUserPaperResponse2());
         return paperResponses;
     }
 }

--- a/src/test/java/com/ktb/paperplebe/paper/fixture/PaperFixture.java
+++ b/src/test/java/com/ktb/paperplebe/paper/fixture/PaperFixture.java
@@ -1,8 +1,11 @@
 package com.ktb.paperplebe.paper.fixture;
 
+import com.ktb.paperplebe.oauth.constant.SocialType;
 import com.ktb.paperplebe.paper.dto.PaperRequest;
 import com.ktb.paperplebe.paper.dto.PaperResponse;
 import com.ktb.paperplebe.paper.entity.Paper;
+import com.ktb.paperplebe.user.constant.UserRole;
+import com.ktb.paperplebe.user.entity.User;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
@@ -28,14 +31,26 @@ public class PaperFixture {
     private static final String IMAGE_URL_1 = "http://example.com/image1.jpg";
     private static final String IMAGE_URL_2 = "http://example.com/image2.jpg";
 
+    public static final User DUMMY_USER = createDummyUser();
+
+    private static User createDummyUser() {
+        return User.builder()
+                .nickname("TestUser")
+                .socialId("testUser123")
+                .role(UserRole.ROLE_USER)
+                .socialType(SocialType.KAKAO)
+                .profileImage("http://example.com/profile.jpg")
+                .build();
+    }
+
     public static Paper createPaper1() {
-        Paper paper = Paper.of(PAPER_TITLE_1, NEWSPAPER_LINK_1, VIEW_COUNT_1, SUMMARY_1, IMAGE_URL_1);
+        Paper paper = Paper.of(PAPER_TITLE_1, NEWSPAPER_LINK_1, VIEW_COUNT_1, SUMMARY_1, IMAGE_URL_1, DUMMY_USER);
         ReflectionTestUtils.setField(paper, "id", PAPER_ID_1);
         return paper;
     }
 
     public static Paper createPaper2() {
-        Paper paper = Paper.of(PAPER_TITLE_2, NEWSPAPER_LINK_2, VIEW_COUNT_2, SUMMARY_2, IMAGE_URL_2);
+        Paper paper = Paper.of(PAPER_TITLE_2, NEWSPAPER_LINK_2, VIEW_COUNT_2, SUMMARY_2, IMAGE_URL_2, DUMMY_USER);
         ReflectionTestUtils.setField(paper, "id", PAPER_ID_2);
         return paper;
     }


### PR DESCRIPTION
# 작업 내용
- AWS S3 이미지 업로드
- 유저 프로필 이미지, 닉네임 수정 기능
- 페이퍼에 user, createdAt 필드 추가
- 페이퍼 기능에 userId 적용
- 사용자가 작성한 페이퍼 목록 조회 기능 추가 (내 페이퍼, 다른 사람의 페이퍼)
- 페이퍼 리스트 반환 시 좋아요 여부 추가
- 페이퍼 컨트롤러 테스트, 페이퍼 좋아요 컨트롤러 테스트 수정 (반환 타입, userId 추가 관련)

# 관련 pr
config: https://github.com/lunch-12/config/pull/1
FE: https://github.com/lunch-12/PAPERPLE-FE/pull/8